### PR TITLE
fix: remove eslint.config.mjs occurence in remix.init files

### DIFF
--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -7,7 +7,7 @@
     "allowImportingTsExtensions": true,
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
   },
-  "include": ["eslint.config.mjs", "src/**/*.ts", "src/**/*.tsx", ".storybook/**/*.ts"],
+  "include": ["eslint.config.js", "src/**/*.ts", "src/**/*.tsx", ".storybook/**/*.ts"],
   "references": [{ "path": "./tsconfig.node.json" }],
   "exclude": ["node_modules", "dist"]
 }

--- a/remix.init/index.mjs
+++ b/remix.init/index.mjs
@@ -303,7 +303,6 @@ const renameAll = async ({
       path.join(rootDirectory, "packages", "**", "*.ts"),
       path.join(rootDirectory, "packages", "**", "*.tsx"),
       path.join(rootDirectory, "packages", "**", "eslint.config.js"),
-      path.join(rootDirectory, "packages", "**", "eslint.config.mjs"),
     ],
     from: new RegExp(orgNameRegex, "g"),
     to: ORG_NAME,


### PR DESCRIPTION
Following #188, there are no more occurrences of `eslint.config.mjs` in `packages/`. This fixes the `remix init` script.

Also fixes minor `tsconfig` reference of the same nature in the `ui` package.