### PR TITLE
[codex] Fix Docker pnpm global install

### DIFF
--- a/apps/webapp/other/Dockerfile
+++ b/apps/webapp/other/Dockerfile
@@ -11,10 +11,11 @@ RUN apt-get update -qq && \
 
 FROM bookworm AS bookworm-turbopm
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
 ENV TURBO_TELEMETRY_MESSAGE_DISABLED=1
 RUN npm install -g corepack@latest
 RUN corepack enable
+RUN corepack prepare pnpm@10.28.0 --activate
 RUN pnpm add turbo@^2 --global
 RUN pnpm config set store-dir ~/.pnpm-store
 

--- a/turbo/generators/templates/Dockerfile.hbs
+++ b/turbo/generators/templates/Dockerfile.hbs
@@ -11,10 +11,11 @@ RUN apt-get update -qq && \
 
 FROM bookworm AS bookworm-turbopm
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
 ENV TURBO_TELEMETRY_MESSAGE_DISABLED=1
 RUN npm install -g corepack@latest
 RUN corepack enable
+RUN corepack prepare pnpm@10.28.0 --activate
 RUN pnpm add turbo@^2 --global
 RUN pnpm config set store-dir ~/.pnpm-store
 


### PR DESCRIPTION
## Summary

Fixes the CI Docker build failure in the `bookworm-turbopm` stage after Corepack started activating pnpm 11 for the pre-copy global install step.

## Root Cause

The Docker stage runs `pnpm add turbo@^2 --global` before any project `package.json` is copied into the image, so Corepack was free to activate the latest pnpm instead of the repo's package manager version. pnpm 11 requires the configured global bin directory (`/pnpm/bin`) to be on `PATH`, but the Dockerfile only included `/pnpm`.

## Changes

- Adds `/pnpm/bin` to `PATH` in the checked-in Dockerfile and generator template.
- Pins Corepack to activate `pnpm@10.28.0`, matching the repo `packageManager`, before installing Turbo globally.
- Applies the same fix to `turbo/generators/templates/Dockerfile.hbs` so newly generated projects inherit it.

## Validation

- `docker build --target bookworm-turbopm -t rrgs-turbopm-ci-fix -f apps/webapp/other/Dockerfile .`

The previously failing `RUN pnpm add turbo@^2 --global` step now succeeds with pnpm `10.28.0` and installs `turbo 2.9.10`.